### PR TITLE
Adapt code for compatibility with newer version of networkx (3.2.1) and metis (5.1.0)

### DIFF
--- a/chameleon.py
+++ b/chameleon.py
@@ -72,8 +72,8 @@ def merge_best(graph, df, a, k, verbose=False):
             print("Merging c%d and c%d" % (ci, cj))
         df.loc[df['cluster'] == cj, 'cluster'] = ci
         for i, p in enumerate(graph.nodes()):
-            if graph.node[p]['cluster'] == cj:
-                graph.node[p]['cluster'] = ci
+            if graph.nodes[p]['cluster'] == cj:
+                graph.nodes[p]['cluster'] = ci
     return max_score > 0
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas
 networkx
 seaborn
 matplotlib
-metis
+pymetis
 tqdm


### PR DESCRIPTION
Previous problems:
- in newer version of networkx, attribute node is replaced by nodes
- crash when part_graph using new version of metis

Fixes implemented:
- graph.node -> graph.nodes
- switch from metis to pymetis to support newer version of metis